### PR TITLE
chore: test invalid credentials

### DIFF
--- a/auth.txt
+++ b/auth.txt
@@ -1,0 +1,1 @@
+"root" "prisma"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,8 @@ services:
     image: brainsam/pgbouncer:1.12.0
     restart: always
     environment:
+      AUTH_FILE: /etc/pgbouncer/auth.txt
+      AUTH_TYPE: md5
       DB_HOST: postgres
       DB_USER: root
       DB_PASSWORD: prisma
@@ -22,6 +24,8 @@ services:
       MAX_CLIENT_CONN: '2'
     ports:
       - 6433:6432
+    volumes:
+      - ${PWD}/auth.txt:/etc/pgbouncer/auth.txt
 
 volumes:
   postgres:

--- a/pg.js
+++ b/pg.js
@@ -1,10 +1,10 @@
 const pg = require('pg')
 
 const pg1 = new pg.Client(
-  `postgresql://root:prisma1@localhost:6433/basic-blog?schema=public&pgbouncer=true`,
+  `postgresql://root:prisma@localhost:6433/basic-blog?schema=public&pgbouncer=true`,
 )
 const pg2 = new pg.Client(
-  `postgresql://root:prisma1@localhost:6433/basic-blog?schema=public&pgbouncer=true`,
+  `postgresql://root:prisma@localhost:6433/basic-blog?schema=public&pgbouncer=true`,
 )
 
 async function main() {

--- a/pg.js
+++ b/pg.js
@@ -1,10 +1,10 @@
 const pg = require('pg')
 
 const pg1 = new pg.Client(
-  `postgresql://root:prisma@localhost:6433/basic-blog?schema=public&pgbouncer=true`,
+  `postgresql://root:prisma1@localhost:6433/basic-blog?schema=public&pgbouncer=true`,
 )
 const pg2 = new pg.Client(
-  `postgresql://root:prisma@localhost:6433/basic-blog?schema=public&pgbouncer=true`,
+  `postgresql://root:prisma1@localhost:6433/basic-blog?schema=public&pgbouncer=true`,
 )
 
 async function main() {


### PR DESCRIPTION
- Setup basic auth on PgBouncer
- PgBouncer still has correct DB credentials
- Client has incorrect PgBouncer credentials

It fails at connect, this is expected. 

Output: 

```
divyendusingh [p2-connect]$ node pg.js                                                                                                                                130 ↵
(node:31351) UnhandledPromiseRejectionWarning: error: password authentication failed
    at Parser.parseErrorMessage (/Users/divyendusingh/Documents/prisma/triage/p2-connect/node_modules/pg-protocol/dist/parser.js:278:15)
    at Parser.handlePacket (/Users/divyendusingh/Documents/prisma/triage/p2-connect/node_modules/pg-protocol/dist/parser.js:126:29)
    at Parser.parse (/Users/divyendusingh/Documents/prisma/triage/p2-connect/node_modules/pg-protocol/dist/parser.js:39:38)
    at Socket.<anonymous> (/Users/divyendusingh/Documents/prisma/triage/p2-connect/node_modules/pg-protocol/dist/index.js:10:42)
    at Socket.emit (events.js:315:20)
    at addChunk (_stream_readable.js:295:12)
    at readableAddChunk (_stream_readable.js:271:9)
    at Socket.Readable.push (_stream_readable.js:212:10)
    at TCP.onStreamRead (internal/stream_base_commons.js:186:23)
(node:31351) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 1)
(node:31351) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.

```